### PR TITLE
allow 0-size MV Properties

### DIFF
--- a/crates/pst/src/ltp/prop_context.rs
+++ b/crates/pst/src/ltp/prop_context.rs
@@ -617,7 +617,7 @@ impl PropertyValueReadWrite for PropertyValue {
 
                     let mut buffer = if i < offsets.len() - 1 {
                         let next = offsets[i + 1];
-                        if next <= start {
+                        if next < start {
                             return Err(LtpError::InvalidMultiValuePropertyOffset(next).into());
                         }
 
@@ -663,7 +663,7 @@ impl PropertyValueReadWrite for PropertyValue {
                     let mut buffer = Vec::new();
                     if i < offsets.len() - 1 {
                         let next = offsets[i + 1];
-                        if next <= start {
+                        if next < start {
                             return Err(LtpError::InvalidMultiValuePropertyOffset(next).into());
                         }
 
@@ -739,7 +739,7 @@ impl PropertyValueReadWrite for PropertyValue {
 
                     let buffer = if i < offsets.len() - 1 {
                         let next = offsets[i + 1];
-                        if next <= start {
+                        if next < start {
                             return Err(LtpError::InvalidMultiValuePropertyOffset(next).into());
                         }
 


### PR DESCRIPTION
It looks like for [MV Properties with Variable-size Base Type](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/45063075-c65d-48cd-a441-f86809bcc6eb) the offsets can be equal, which denotes a 0 size entry, which is apparently legal.

This fixes https://github.com/microsoft/outlook-pst-rs/issues/24, in particular the output of the reproducer is:

```
root folder: Início do ficheiro de dados do Outlook
found 14 subfolders
subfolder 0: 'Itens eliminados' (0 messages)
subfolder 1: 'Caixa de Entrada' (3 messages)
subfolder 2: 'A enviar' (0 messages)
subfolder 3: 'Itens enviados' (0 messages)
subfolder 4: 'Calendário' (0 messages)
subfolder 5: 'Contactos' (0 messages)
subfolder 6: 'Diário' (0 messages)
subfolder 7: 'Notas' (0 messages)
subfolder 8: 'Tarefas' (0 messages)
subfolder 9: 'Rascunhos' (0 messages)
subfolder 10: 'Feeds RSS' (0 messages)
subfolder 11: 'Definições da Ação de Conversação' (0 messages)
subfolder 12: 'Definições do Passo Rápido' (0 messages)
subfolder 13: 'E-mail de Lixo' (0 messages)
```