### PR TITLE
chore: use trusted publishing instead of API key secret

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,10 +22,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Authenticate crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@1528104d2ca23787631a1c1f022abb64b34c1e11
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
The API key for crates.io has expired, and rather than refresh it from my personal account and rotate the secret, I'm switching these crates to use [trusted publishing](https://crates.io/docs/trusted-publishing) with the release workflow.